### PR TITLE
chore: update to v0.13.1

### DIFF
--- a/external-dns.yaml
+++ b/external-dns.yaml
@@ -10,14 +10,17 @@ metadata:
   name: external-dns
 rules:
 - apiGroups: [ "" ]
-  resources: [ "services","endpoints","pods" ]
-  verbs: [ "get","watch","list" ]
-- apiGroups: [ "extensions","networking.k8s.io" ]
+  resources: [ "endpoints", "pods", "services" ]
+  verbs: [ "get", "watch", "list" ]
+- apiGroups: [ "extensions" ]
+  resources: [ "ingresses" ]
+  verbs: [ "get", "watch", "list" ]
+- apiGroups: [ "networking.k8s.io" ]
   resources: [ "ingresses" ]
   verbs: [ "get","watch","list" ]
 - apiGroups: [ "" ]
   resources: [ "nodes" ]
-  verbs: [ "list","watch" ]
+  verbs: [ "watch", "list" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -51,7 +54,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: k8s.gcr.io/external-dns/external-dns:v0.10.0
+        image: k8s.gcr.io/external-dns/external-dns:v0.13.1
         args:
         - --source=service
         - --source=ingress
@@ -62,24 +65,5 @@ spec:
         env:
         - name: AWS_DEFAULT_REGION
           value: "${region}"
-        - name: AWS_REGION
-          value: "${region}"
-        - name: AWS_ROLE_ARN
-          value: "arn:aws:iam::${account_id}:role/external-dns.kube-system.sa.${name}"
-        - name: AWS_WEB_IDENTITY_TOKEN_FILE
-          value: "/var/run/secrets/amazonaws.com/serviceaccount/token"
-        - name: AWS_STS_REGIONAL_ENDPOINTS
-          value: "regional"
-        volumeMounts:
-        - mountPath: "/var/run/secrets/amazonaws.com/serviceaccount/"
-          name: aws-token
-      volumes:
-      - name: aws-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: "amazonaws.com"
-              expirationSeconds: 86400
-              path: token
       securityContext:
         fsGroup: 65534

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,7 @@ output "permissions" {
 output "addon" {
   value = {
     name : "external-dns"
-    version : "0.10.0"
+    version : "0.13.1"
     content : local.yaml
   }
 }


### PR DESCRIPTION
Note! This version assumes that pod-identity-webhook is used.