### PR TITLE
Update External DNS version

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,43 @@
+---
+name: Updatecli
+
+on:
+  # Trigger Updatecli if a new commit land on the main branch
+  push:
+    branches: [ main ]
+  # Trigger Updatecli if a pullrequest is open targeting the main branch.
+  # This is useful to test Updatecli manifest change
+  pull_request:
+    branches: [ main ]
+  # Manually trigger Updatecli via GitHub UI
+  workflow_dispatch:
+  # Trigger Updatecli once day by a cronjob
+  schedule:
+  # * is a special character in YAML, so you have to quote this string
+  # Run once a day
+  - cron: '0 0 * * *'
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+jobs:
+  updatecli:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@v2
+
+    - uses: azure/setup-kubectl@v4
+      id: kubectl
+
+    - uses: azure/setup-helm@v4.2.0
+      id: helm
+
+    - name: Run Updatecli in apply mode
+      run: "updatecli --experimental apply --config ./updatecli/updatecli.d --values updatecli/values.yaml --clean=true"
+      env:
+        UPDATECLI_GITHUB_TOKEN: "${{ secrets.UPDATECLI_GITHUB_TOKEN }}"

--- a/updatecli/updatecli.d/external-dns.yaml
+++ b/updatecli/updatecli.d/external-dns.yaml
@@ -1,0 +1,83 @@
+sources:
+  lastRelease:
+    kind: helmchart
+    spec:
+      url: 'https://kubernetes-sigs.github.io/external-dns/'
+      name: 'external-dns'
+  lastImageRelease:
+    kind: githubrelease
+    spec:
+      owner: 'kubernetes-sigs'
+      repository: 'external-dns'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+
+targets:
+  chart:
+    name: bump chart version
+    kind: yaml
+    scmid: github
+    sourceid: lastRelease
+    spec:
+      file: 'external-dns/kustomization.yaml'
+      key: '$.helmCharts[0].version'
+    transformers:
+    - addprefix: "'"
+    - addsuffix: "'"
+  image:
+    name: Bump image version
+    kind: yaml
+    scmid: github
+    sourceid: lastImageRelease
+    spec:
+      file: 'external-dns/values.yaml'
+      key: '$.image.tag'
+  module_version:
+    name: bump module version
+    kind: hcl
+    scmid: github
+    sourceid: lastImageRelease
+    spec:
+      file: 'locals.tf'
+      path: 'locals.version'
+    transformers:
+    - trimprefix: "v"
+  kubectl:
+    name: run kubectl when chart changed
+    kind: shell
+    scmid: github
+    dependson:
+    - module_version
+    - chart
+    dependsonchange: true
+    disablesourceinput: true
+    spec:
+      command: "rm -rf external-dns/charts && kubectl kustomize . -o external-dns.yaml --enable-helm && git diff --shortstat external-dns.yaml"
+      environments:
+      - name: PATH
+
+scms:
+  github:
+    kind: "github"
+    spec:
+      user: "argoyle"
+      email: "updatecli@opzkit.io"
+      owner: "opzkit"
+      repository: "terraform-aws-k8s-addons-external-dns"
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: 'UpdateCLI'
+      branch: "main"
+      commitusingapi: true
+
+# Define action configurations if one needs to be created
+actions:
+  addon:
+    kind: "github/pullrequest"
+    scmid: "github"
+    spec:
+      automerge: true
+      draft: false
+      labels:
+      - "dependencies"
+      title: "Update External DNS version"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,4 @@
+github:
+  user: "UpdateCLI"
+  email: "updatecli@opzkit.io"
+  username: "github-actions"


### PR DESCRIPTION



<Actions>
    <action id="400df2f1cd43d43bbc7a7ca666b35a6594cd3da4f3937fa79f28e78cc51f396f">
        <h3>EXTERNAL-DNS.YAML</h3>
        <details id="ab0ee30df2545cedb3139e6e8ff673a28e83a5be18809abc7c541d44cf4468d0">
            <summary>bump module version</summary>
            <p>changes detected:&#xA;&#x9;path &#34;locals.version&#34; updated from &#34;0.14.0&#34; to &#34;0.15.0&#34; in file &#34;locals.tf&#34;</p>
            <details>
                <summary>v0.15.0</summary>
                <pre>&#xA;Release published on the 2024-09-04 15:24:57 +0000 UTC at the url https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0&#xA;&#xA;## Important notes&#xD;&#xA;&#xD;&#xA;This release drops a few unmaintained providers. See https://github.com/kubernetes-sigs/external-dns/pull/4719 as mentioned in https://github.com/kubernetes-sigs/external-dns/issues/4347. If you need to use any of the previous providers, please use a previous release of external DNS or follow the instructions to implement a webhook provider that supports those providers.&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;* build(deps): bump actions/checkout from 4.1.5 to 4.1.6 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4477&#xD;&#xA;* Update kustomize version for v0.14.2 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4480&#xD;&#xA;* build(deps): bump the dev-dependencies group with 8 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4478&#xD;&#xA;* update docs to v0.14.2 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4481&#xD;&#xA;* build(deps): bump GrantBirki/json-yaml-validate from 2.7.1 to 3.0.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4489&#xD;&#xA;* fix: re-add api-approved.kubernetes.io annotation by @morremeyer in https://github.com/kubernetes-sigs/external-dns/pull/4488&#xD;&#xA;* feat(webhooks): pass webhook-* annotations to webhook providers by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4458&#xD;&#xA;* fix(traefik): Nil pointer exception if legacy traefik is disabled by @kbudde in https://github.com/kubernetes-sigs/external-dns/pull/4502&#xD;&#xA;* add unifi webhook to readme by @onedr0p in https://github.com/kubernetes-sigs/external-dns/pull/4504&#xD;&#xA;* Drop experimental notice in webhook flags by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4507&#xD;&#xA;* feat(coredns): etcd authentication by @matthieugouel in https://github.com/kubernetes-sigs/external-dns/pull/4503&#xD;&#xA;* Bump the dev-dependencies group across 1 directory with 13 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4514&#xD;&#xA;* Add Infoblox webhook provider by @k0da in https://github.com/kubernetes-sigs/external-dns/pull/4513&#xD;&#xA;* 🌱 docs(footer): Add trademark disclaimer by @mariasalcedo in https://github.com/kubernetes-sigs/external-dns/pull/4529&#xD;&#xA;* chore!: Remove infoblox in-tree provider by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4516&#xD;&#xA;* Update to Go 1.22.4 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4534&#xD;&#xA;* Bump the dev-dependencies group across 1 directory with 19 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4536&#xD;&#xA;* Add documentation about etcd HTTPS for CoreDNS provider by @AlessandroZanatta in https://github.com/kubernetes-sigs/external-dns/pull/4538&#xD;&#xA;* chore(chart): Released chart for v0.14.2 by @stevehipwell in https://github.com/kubernetes-sigs/external-dns/pull/4541&#xD;&#xA;* Bump the dev-dependencies group with 4 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4540&#xD;&#xA;* feat(aws): use AWS profiles using .credentials file by @roehrijn in https://github.com/kubernetes-sigs/external-dns/pull/3973&#xD;&#xA;* fix(cloudflare): trimSpace on token read from file by @simonostendorf in https://github.com/kubernetes-sigs/external-dns/pull/4515&#xD;&#xA;* docs: upgrade mkdocs and fix broken links by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4378&#xD;&#xA;* chore(deps): bump github.com/vektah/gqlparser/v2 from 2.5.1 to 2.5.14 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4546&#xD;&#xA;* chore(deps): bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.5.2 to 1.6.0 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4544&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 19 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4562&#xD;&#xA;* chore(deps): bump actions/checkout from 4.1.6 to 4.1.7 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4547&#xD;&#xA;* feat(rfc2136): add PTR optional support by @angeloxx in https://github.com/kubernetes-sigs/external-dns/pull/4283&#xD;&#xA;* Update cloudflare.md by @tobiabocchi in https://github.com/kubernetes-sigs/external-dns/pull/4583&#xD;&#xA;* feat!: update GRPCRoute client from v1alpha2 to stable v1 by @thameezb in https://github.com/kubernetes-sigs/external-dns/pull/4567&#xD;&#xA;* docs(annotations): note how to set multiple hostnames by @hopkinsth in https://github.com/kubernetes-sigs/external-dns/pull/4602&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4604&#xD;&#xA;* Gateway API: Revert Gateway and HTTPRoute objects from v1 to v1beta1 by @abursavich in https://github.com/kubernetes-sigs/external-dns/pull/4610&#xD;&#xA;* chore(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4600&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 37 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4655&#xD;&#xA;* docs: fix broken link by @ilmax in https://github.com/kubernetes-sigs/external-dns/pull/4662&#xD;&#xA;* azure-private-dns: Fix LoadBalancer example by @orgads in https://github.com/kubernetes-sigs/external-dns/pull/4663&#xD;&#xA;* AWS: Change documentation to use Helm values by @pier-oliviert in https://github.com/kubernetes-sigs/external-dns/pull/4577&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 10 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4668&#xD;&#xA;* Improve MinEventInterval compliance with docs by @tjamet in https://github.com/kubernetes-sigs/external-dns/pull/3400&#xD;&#xA;* Add provider cache by @tjamet in https://github.com/kubernetes-sigs/external-dns/pull/4597&#xD;&#xA;* chore: update maintainers by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4679&#xD;&#xA;* fix(helm): make use of resource values for webhook by @crutonjohn in https://github.com/kubernetes-sigs/external-dns/pull/4560&#xD;&#xA;* Fix AWS Cloud Map docs: annotation key/value pairs must be strings by @mjlshen in https://github.com/kubernetes-sigs/external-dns/pull/4683&#xD;&#xA;* Webhook provider helm chart fixes by @kimsondrup in https://github.com/kubernetes-sigs/external-dns/pull/4643&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 16 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4684&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.0.0 to 3.1.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4685&#xD;&#xA;* Add tutorial to DynamoDB registry docs by @mjlshen in https://github.com/kubernetes-sigs/external-dns/pull/4686&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.1.0 to 3.2.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4700&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.2.0 to 3.2.1 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4702&#xD;&#xA;* chore: upgrade ExternalDNS to go 1.23 by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4698&#xD;&#xA;* feat: add annotation and label filters to Ambassador Host Source by @KyleMartin901 in https://github.com/kubernetes-sigs/external-dns/pull/2633&#xD;&#xA;* Add RouterOS provider to README.md by @benfiola in https://github.com/kubernetes-sigs/external-dns/pull/4714&#xD;&#xA;* feat: support dual stack for gateway api by @thameezb in https://github.com/kubernetes-sigs/external-dns/pull/4469&#xD;&#xA;* chore(deps): bump actions/setup-python from 5.1.1 to 5.2.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4712&#xD;&#xA;* chore: remove unmaintained providers by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4719&#xD;&#xA;&#xD;&#xA;## Images&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;docker pull registry.k8s.io/external-dns/external-dns:v0.15.0&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @kbudde made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4502&#xD;&#xA;* @matthieugouel made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4503&#xD;&#xA;* @mariasalcedo made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4529&#xD;&#xA;* @AlessandroZanatta made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4538&#xD;&#xA;* @roehrijn made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/3973&#xD;&#xA;* @simonostendorf made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4515&#xD;&#xA;* @angeloxx made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4283&#xD;&#xA;* @tobiabocchi made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4583&#xD;&#xA;* @thameezb made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4567&#xD;&#xA;* @hopkinsth made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4602&#xD;&#xA;* @ilmax made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4662&#xD;&#xA;* @orgads made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4663&#xD;&#xA;* @pier-oliviert made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4577&#xD;&#xA;* @crutonjohn made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4560&#xD;&#xA;* @mjlshen made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4683&#xD;&#xA;* @kimsondrup made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4643&#xD;&#xA;* @KyleMartin901 made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/2633&#xD;&#xA;* @benfiola made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4714&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/kubernetes-sigs/external-dns/compare/v0.14.2...v0.15.0</pre>
            </details>
        </details>
        <details id="7a7f09de08e3dc01c5bbf90657ecc83d5c2da9f5791f1ebe84132b95422878dc">
            <summary>run kubectl when chart changed</summary>
            <p>ran shell command &#34;rm -rf external-dns/charts &amp;&amp; kubectl kustomize . -o external-dns.yaml --enable-helm &amp;&amp; git diff --shortstat external-dns.yaml&#34;</p>
        </details>
        <details id="cc57fc1903e444cf6a726490b43b27ee9f87facc037f86872201847c565b45fb">
            <summary>bump chart version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.helmCharts[0].version&#34; updated from &#34;&#39;1.14.0&#39;&#34; to &#34;&#39;1.14.5&#39;&#34;, in file &#34;external-dns/kustomization.yaml&#34;</p>
            <details>
                <summary>1.14.5</summary>
                <pre>&#xA;Remark: We couldn&#39;t identify a way to automatically retrieve changelog information.&#xA;Please use following information to take informed decision&#xA;&#xA;Helm Chart: external-dns&#xA;ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.&#xA;Project Home: https://github.com/kubernetes-sigs/external-dns/&#xA;&#xA;Version created on the 2024-06-10 15:14:44.347990873 &amp;#43;0000 UTC&#xA;&#xA;Sources:&#xA;&#xA;* https://github.com/kubernetes-sigs/external-dns/&#xA;&#xA;&#xA;&#xA;URL:&#xA;&#xA;* https://github.com/kubernetes-sigs/external-dns/releases/download/external-dns-helm-chart-1.14.5/external-dns-1.14.5.tgz&#xA;&#xA;&#xA;</pre>
            </details>
        </details>
        <details id="6105d6cc76af400325e94d588ce511be5bfdbb73b437dc51eca43917d7a43e3d">
            <summary>Bump image version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.image.tag&#34; updated from &#34;&#39;v0.14.0&#39;&#34; to &#34;v0.15.0&#34;, in file &#34;external-dns/values.yaml&#34;</p>
            <details>
                <summary>v0.15.0</summary>
                <pre>&#xA;Release published on the 2024-09-04 15:24:57 +0000 UTC at the url https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0&#xA;&#xA;## Important notes&#xD;&#xA;&#xD;&#xA;This release drops a few unmaintained providers. See https://github.com/kubernetes-sigs/external-dns/pull/4719 as mentioned in https://github.com/kubernetes-sigs/external-dns/issues/4347. If you need to use any of the previous providers, please use a previous release of external DNS or follow the instructions to implement a webhook provider that supports those providers.&#xD;&#xA;&#xD;&#xA;## What&#39;s Changed&#xD;&#xA;* build(deps): bump actions/checkout from 4.1.5 to 4.1.6 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4477&#xD;&#xA;* Update kustomize version for v0.14.2 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4480&#xD;&#xA;* build(deps): bump the dev-dependencies group with 8 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4478&#xD;&#xA;* update docs to v0.14.2 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4481&#xD;&#xA;* build(deps): bump GrantBirki/json-yaml-validate from 2.7.1 to 3.0.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4489&#xD;&#xA;* fix: re-add api-approved.kubernetes.io annotation by @morremeyer in https://github.com/kubernetes-sigs/external-dns/pull/4488&#xD;&#xA;* feat(webhooks): pass webhook-* annotations to webhook providers by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4458&#xD;&#xA;* fix(traefik): Nil pointer exception if legacy traefik is disabled by @kbudde in https://github.com/kubernetes-sigs/external-dns/pull/4502&#xD;&#xA;* add unifi webhook to readme by @onedr0p in https://github.com/kubernetes-sigs/external-dns/pull/4504&#xD;&#xA;* Drop experimental notice in webhook flags by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4507&#xD;&#xA;* feat(coredns): etcd authentication by @matthieugouel in https://github.com/kubernetes-sigs/external-dns/pull/4503&#xD;&#xA;* Bump the dev-dependencies group across 1 directory with 13 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4514&#xD;&#xA;* Add Infoblox webhook provider by @k0da in https://github.com/kubernetes-sigs/external-dns/pull/4513&#xD;&#xA;* 🌱 docs(footer): Add trademark disclaimer by @mariasalcedo in https://github.com/kubernetes-sigs/external-dns/pull/4529&#xD;&#xA;* chore!: Remove infoblox in-tree provider by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4516&#xD;&#xA;* Update to Go 1.22.4 by @Raffo in https://github.com/kubernetes-sigs/external-dns/pull/4534&#xD;&#xA;* Bump the dev-dependencies group across 1 directory with 19 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4536&#xD;&#xA;* Add documentation about etcd HTTPS for CoreDNS provider by @AlessandroZanatta in https://github.com/kubernetes-sigs/external-dns/pull/4538&#xD;&#xA;* chore(chart): Released chart for v0.14.2 by @stevehipwell in https://github.com/kubernetes-sigs/external-dns/pull/4541&#xD;&#xA;* Bump the dev-dependencies group with 4 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4540&#xD;&#xA;* feat(aws): use AWS profiles using .credentials file by @roehrijn in https://github.com/kubernetes-sigs/external-dns/pull/3973&#xD;&#xA;* fix(cloudflare): trimSpace on token read from file by @simonostendorf in https://github.com/kubernetes-sigs/external-dns/pull/4515&#xD;&#xA;* docs: upgrade mkdocs and fix broken links by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4378&#xD;&#xA;* chore(deps): bump github.com/vektah/gqlparser/v2 from 2.5.1 to 2.5.14 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4546&#xD;&#xA;* chore(deps): bump github.com/Azure/azure-sdk-for-go/sdk/azidentity from 1.5.2 to 1.6.0 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4544&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 19 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4562&#xD;&#xA;* chore(deps): bump actions/checkout from 4.1.6 to 4.1.7 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4547&#xD;&#xA;* feat(rfc2136): add PTR optional support by @angeloxx in https://github.com/kubernetes-sigs/external-dns/pull/4283&#xD;&#xA;* Update cloudflare.md by @tobiabocchi in https://github.com/kubernetes-sigs/external-dns/pull/4583&#xD;&#xA;* feat!: update GRPCRoute client from v1alpha2 to stable v1 by @thameezb in https://github.com/kubernetes-sigs/external-dns/pull/4567&#xD;&#xA;* docs(annotations): note how to set multiple hostnames by @hopkinsth in https://github.com/kubernetes-sigs/external-dns/pull/4602&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 2 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4604&#xD;&#xA;* Gateway API: Revert Gateway and HTTPRoute objects from v1 to v1beta1 by @abursavich in https://github.com/kubernetes-sigs/external-dns/pull/4610&#xD;&#xA;* chore(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4600&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 37 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4655&#xD;&#xA;* docs: fix broken link by @ilmax in https://github.com/kubernetes-sigs/external-dns/pull/4662&#xD;&#xA;* azure-private-dns: Fix LoadBalancer example by @orgads in https://github.com/kubernetes-sigs/external-dns/pull/4663&#xD;&#xA;* AWS: Change documentation to use Helm values by @pier-oliviert in https://github.com/kubernetes-sigs/external-dns/pull/4577&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 10 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4668&#xD;&#xA;* Improve MinEventInterval compliance with docs by @tjamet in https://github.com/kubernetes-sigs/external-dns/pull/3400&#xD;&#xA;* Add provider cache by @tjamet in https://github.com/kubernetes-sigs/external-dns/pull/4597&#xD;&#xA;* chore: update maintainers by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4679&#xD;&#xA;* fix(helm): make use of resource values for webhook by @crutonjohn in https://github.com/kubernetes-sigs/external-dns/pull/4560&#xD;&#xA;* Fix AWS Cloud Map docs: annotation key/value pairs must be strings by @mjlshen in https://github.com/kubernetes-sigs/external-dns/pull/4683&#xD;&#xA;* Webhook provider helm chart fixes by @kimsondrup in https://github.com/kubernetes-sigs/external-dns/pull/4643&#xD;&#xA;* chore(deps): bump the dev-dependencies group across 1 directory with 16 updates by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4684&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.0.0 to 3.1.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4685&#xD;&#xA;* Add tutorial to DynamoDB registry docs by @mjlshen in https://github.com/kubernetes-sigs/external-dns/pull/4686&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.1.0 to 3.2.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4700&#xD;&#xA;* chore(deps): bump GrantBirki/json-yaml-validate from 3.2.0 to 3.2.1 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4702&#xD;&#xA;* chore: upgrade ExternalDNS to go 1.23 by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4698&#xD;&#xA;* feat: add annotation and label filters to Ambassador Host Source by @KyleMartin901 in https://github.com/kubernetes-sigs/external-dns/pull/2633&#xD;&#xA;* Add RouterOS provider to README.md by @benfiola in https://github.com/kubernetes-sigs/external-dns/pull/4714&#xD;&#xA;* feat: support dual stack for gateway api by @thameezb in https://github.com/kubernetes-sigs/external-dns/pull/4469&#xD;&#xA;* chore(deps): bump actions/setup-python from 5.1.1 to 5.2.0 in the dev-dependencies group by @dependabot in https://github.com/kubernetes-sigs/external-dns/pull/4712&#xD;&#xA;* chore: remove unmaintained providers by @mloiseleur in https://github.com/kubernetes-sigs/external-dns/pull/4719&#xD;&#xA;&#xD;&#xA;## Images&#xD;&#xA;&#xD;&#xA;```&#xD;&#xA;docker pull registry.k8s.io/external-dns/external-dns:v0.15.0&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @kbudde made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4502&#xD;&#xA;* @matthieugouel made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4503&#xD;&#xA;* @mariasalcedo made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4529&#xD;&#xA;* @AlessandroZanatta made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4538&#xD;&#xA;* @roehrijn made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/3973&#xD;&#xA;* @simonostendorf made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4515&#xD;&#xA;* @angeloxx made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4283&#xD;&#xA;* @tobiabocchi made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4583&#xD;&#xA;* @thameezb made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4567&#xD;&#xA;* @hopkinsth made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4602&#xD;&#xA;* @ilmax made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4662&#xD;&#xA;* @orgads made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4663&#xD;&#xA;* @pier-oliviert made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4577&#xD;&#xA;* @crutonjohn made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4560&#xD;&#xA;* @mjlshen made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4683&#xD;&#xA;* @kimsondrup made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4643&#xD;&#xA;* @KyleMartin901 made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/2633&#xD;&#xA;* @benfiola made their first contribution in https://github.com/kubernetes-sigs/external-dns/pull/4714&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/kubernetes-sigs/external-dns/compare/v0.14.2...v0.15.0</pre>
            </details>
        </details>
        <a href="https://github.com/opzkit/terraform-aws-k8s-addons-external-dns/actions/runs/10719687217">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

