### PR TITLE
chore: remove pull_request trigger from updatecli workflow

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -5,10 +5,6 @@ on:
   # Trigger Updatecli if a new commit land on the main branch
   push:
     branches: [ main ]
-  # Trigger Updatecli if a pullrequest is open targeting the main branch.
-  # This is useful to test Updatecli manifest change
-  pull_request:
-    branches: [ main ]
   # Manually trigger Updatecli via GitHub UI
   workflow_dispatch:
   # Trigger Updatecli once day by a cronjob


### PR DESCRIPTION
Eliminate the pull_request trigger from the Updatecli workflow to
streamline operations and focus on direct commits to the main branch. 
This change simplifies the workflow by reducing unnecessary triggers.