### PR TITLE
chore: update provider source and versions for AWS and Kops

### DIFF
--- a/examples/basic/provider.tf
+++ b/examples/basic/provider.tf
@@ -6,7 +6,6 @@ provider "aws" {
   skip_requesting_account_id  = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
-  s3_force_path_style         = true
   region                      = "eu-west-1"
   access_key                  = "mock_access_key"
   secret_key                  = "mock_secret_key"
@@ -15,13 +14,13 @@ provider "aws" {
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "1.21.0"
+      source  = "terraform-kops/kops"
+      version = "1.31.0"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 1.1.9"

--- a/examples/txt-prefix/provider.tf
+++ b/examples/txt-prefix/provider.tf
@@ -6,7 +6,6 @@ provider "aws" {
   skip_requesting_account_id  = true
   skip_credentials_validation = true
   skip_metadata_api_check     = true
-  s3_force_path_style         = true
   region                      = "eu-west-1"
   access_key                  = "mock_access_key"
   secret_key                  = "mock_secret_key"
@@ -15,13 +14,13 @@ provider "aws" {
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "1.21.0"
+      source  = "terraform-kops/kops"
+      version = "1.31.0"
     }
 
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 1.1.9"


### PR DESCRIPTION
Update the Kops provider source to "terraform-kops/kops" and 
bump the version to "1.31.0". Also, update the AWS provider 
version to "~> 5.0". Remove unnecessary S3 configuration 
parameters for clarity. These changes ensure compatibility with 
latest provider updates and improve maintainability.