### PR TITLE
fix: remove unnecessary transformers from external-dns.yaml

### DIFF
--- a/updatecli/updatecli.d/external-dns.yaml
+++ b/updatecli/updatecli.d/external-dns.yaml
@@ -22,9 +22,6 @@ targets:
     spec:
       file: 'external-dns/kustomization.yaml'
       key: '$.helmCharts[0].version'
-    transformers:
-    - addprefix: "'"
-    - addsuffix: "'"
   image:
     name: bump image version to {{ source "lastImageRelease" }}
     kind: yaml


### PR DESCRIPTION
Eliminate the addprefix and addsuffix transformers from the 
external-dns.yaml configuration, as they are no longer needed 
for the deployment. This simplifies the file and improves 
readability.