### PR TITLE
feat(config): disable kustomize in Renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>opzkit/renovate-config"
-  ]
+  ],
+  "kustomize": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Add "kustomize" configuration with "enabled" set to false in 
renovate.json to prevent Kustomize updates. This change ensures 
that the project focuses on other package updates without 
interference from Kustomize configurations.